### PR TITLE
Add close project API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a more detailed app version number on the home screen
 - Updated docs and release notes for 1.1.0
 - REMIX-4403: Added a shell script to open a project for Visual Studio debugging
+- Added close project API endpoint
 
 ### Changed
 - Changed GH actions commit message to commit title and non interruptible Gitlab releases

--- a/source/extensions/lightspeed.layer_manager.core/config/extension.toml
+++ b/source/extensions/lightspeed.layer_manager.core/config/extension.toml
@@ -1,5 +1,5 @@
 [package]
-version = "3.0.2"
+version = "3.0.3"
 authors = ["dbataille@nvidia.com"]
 repository = "https://gitlab-master.nvidia.com/lightspeedrtx/lightspeed-kit"
 changelog = "docs/CHANGELOG.md"

--- a/source/extensions/lightspeed.layer_manager.core/docs/CHANGELOG.md
+++ b/source/extensions/lightspeed.layer_manager.core/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.0.3]
+### Added
+- Added `close_project_with_data_models` method to close stage via context
+
 ## [3.0.2]
 ## Fixed
 - Fixed validation when layer cannot be opened

--- a/source/extensions/lightspeed.layer_manager.core/lightspeed/layer_manager/core/core.py
+++ b/source/extensions/lightspeed.layer_manager.core/lightspeed/layer_manager/core/core.py
@@ -91,6 +91,20 @@ class LayerManagerCore:
     def open_project_with_data_models(self, params: OpenProjectPathParamModel):
         self.__context.open_stage(str(params.layer_id))
 
+    def close_project_with_data_models(self, force: bool = False):
+        # Return early if no stage is loaded
+        if not self.__context.get_stage():
+            return
+
+        # Raise exception if there are unsaved changes and force is False
+        if self.__context.has_pending_edit() and not force:
+            raise ValueError(
+                "The stage has pending changes. Please save the pending changes or "
+                "set the force flag to True to discard the pending changes and close the project."
+            )
+
+        self.__context.close_stage()
+
     def get_layer_stack_with_data_models(self, query: GetLayersQueryModel) -> LayerStackResponseModel:
         if query.layer_types is not None:
             layers_dict = {}

--- a/source/extensions/lightspeed.project_manager.service/config/extension.toml
+++ b/source/extensions/lightspeed.project_manager.service/config/extension.toml
@@ -1,5 +1,5 @@
 [package]
-version = "2.0.1"
+version = "2.0.2"
 authors =["Pierre-Oliver Trottier <ptrottier@nvidia.com>"]
 changelog = "docs/CHANGELOG.md"
 readme = "docs/README.md"

--- a/source/extensions/lightspeed.project_manager.service/docs/CHANGELOG.md
+++ b/source/extensions/lightspeed.project_manager.service/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.0.2]
+### Added
+- Added close project API endpoint to close the currently open project
+
 ## [2.0.1]
 ## Fixed
 - Fixed Test assets to large to work without LFS

--- a/source/extensions/lightspeed.project_manager.service/lightspeed/project_manager/service/service.py
+++ b/source/extensions/lightspeed.project_manager.service/lightspeed/project_manager/service/service.py
@@ -58,3 +58,15 @@ class ProjectManagerService(ServiceBase):
             )
         ) -> str:
             return self.__layer_core.open_project_with_data_models(layer_id) or "OK"
+
+        @self.router.delete(path="/", operation_id="close_project", description="Close the currently open project.")
+        async def close_project(
+            force: bool = ServiceBase.describe_query_param(  # noqa B008
+                False, "Whether to force close the project even if there are pending changes."
+            )
+        ) -> str:
+            try:
+                return self.__layer_core.close_project_with_data_models(force=force) or "OK"
+            except ValueError as e:
+                # Convert ValueError to 403 Forbidden error for pending changes
+                raise ServiceBase.raise_error(403, e)


### PR DESCRIPTION
  - Add DELETE /project/ endpoint to ProjectManagerService
  - Add close_project_with_data_models() method to LayerManagerCore
  - API returns 'OK' status when project is closed successfully
  - Tested and verified working via API calls
  
  Will Complete
  
[this issue](https://github.com/NVIDIAGameWorks/rtx-remix/issues/817)