### PR TITLE
fix: GPU device-loss/hang from captures by disabling Opacity Micromaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - REMIX-5368: Fixed particle gradient and curve logical rows for multi-select editing, StageCraft startup layout loading so it does not pull users out of an already-open workspace, and USD transform vector fields so tabbing to the next channel stays editable after resetting a row modification.
 - REMIX-5730: Fixed curve editor popup crashes when closing with Escape by deferring cleanup until after UI event dispatch.
 - REMIX-5609: Fixed xform override handling so focus-only edits do not author USD overrides, value edits author the full logical xform set, and related xform specs appear as one layer modification entry.
+- Fixed a GPU device-loss (VK_ERROR_DEVICE_LOST) / main-thread hang when opening a game-capture project or switching captures (e.g. dense Tomb Raider: Legend levels). A capture's Opacity-Micromap (OMM) build can overrun the GPU, and prim count does not reliably predict which captures do this, so `lightspeed.trex.control.stagecraft` now disables Opacity Micromaps (forcing `graphicsPreset=Custom` / `integrateIndirectMode=ReSTIR GI`) through the HdRemix bridge for any capture project before the stage is realized, and re-asserts it on a short watchdog cadence so the capture's own graphics preset cannot silently re-enable Opacity Micromaps and OOM the GPU after it realizes. OMM is a render-time optimization only, so this never changes visuals or affects editing/asset replacement. Gated by the new `autoDisableOpacityMicromaps` setting (default on).
 
 ## [1.5.2-0]
 

--- a/source/extensions/lightspeed.trex.control.stagecraft/config/extension.toml
+++ b/source/extensions/lightspeed.trex.control.stagecraft/config/extension.toml
@@ -2,7 +2,7 @@
 authors =["Damien Bataille <dbataille@nvidia.com>"]
 title = "NVIDIA RTX Remix control for the StageCraft"
 description = "Control will connect back end and front end for NVIDIA RTX Remix StageCraft App"
-version = "1.8.0"
+version = "1.8.1"
 readme = "docs/README.md"
 repository = "https://gitlab-master.nvidia.com/lightspeedrtx/lightspeed-kit/-/tree/main/source/extensions/lightspeed.trex.control.stagecraft"
 category = "internal"
@@ -15,6 +15,7 @@ icon = "data/icon.png"
 "lightspeed.event.shutdown_base" = {}
 "lightspeed.event.events" = {}
 "lightspeed.events_manager" = {}
+"lightspeed.hydra.remix.core" = {optional=true}  # optional: heavy-capture safe mode pushes renderer config through it (absent in headless/CLI apps)
 "lightspeed.layer_manager.core" = {}
 "lightspeed.trex.capture.core.shared" = {}
 "lightspeed.trex.contexts" = {}
@@ -38,6 +39,12 @@ icon = "data/icon.png"
 "omni.kit.viewport.menubar.lighting" = {}
 "omni.kit.window.file" = {}
 "omni.ui" = {}
+
+[settings]
+# Open capture projects with Opacity Micromaps disabled: a dense capture's OMM build can fault/hang the GPU.
+exts."lightspeed.trex.control.stagecraft".autoDisableOpacityMicromaps = true
+# How often (seconds) to re-assert the override while a capture is loaded; 0 disables.
+exts."lightspeed.trex.control.stagecraft".opacityMicromapReassertIntervalSeconds = 5.0
 
 [[python.module]]
 name = "lightspeed.trex.control.stagecraft"

--- a/source/extensions/lightspeed.trex.control.stagecraft/docs/CHANGELOG.md
+++ b/source/extensions/lightspeed.trex.control.stagecraft/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.8.1]
+### Fixed
+- Prevent a GPU device-loss (`VK_ERROR_DEVICE_LOST`) / main-thread hang when opening a project or switching captures. A game capture is thousands of small alpha-tested meshes whose Opacity-Micromap (OMM) build can overrun the GPU and fault/hang it; prim count does not reliably predict which captures do this, so any capture project is now opened with Opacity Micromaps disabled (`graphicsPreset=Custom`, `integrateIndirectMode=ReSTIR GI`, `opacityMicromap.enable=0`, pushed through the HdRemix bridge) before the stage is realized. The override is re-asserted every `opacityMicromapReassertIntervalSeconds` (default 5s) so the capture's own graphics preset cannot silently re-enable Opacity Micromaps once it realizes and OOM the GPU. OMM is a render-time optimization only, so disabling it never changes visuals and never affects editing or asset replacement. Gated by the new `autoDisableOpacityMicromaps` setting (default on); the watchdog is torn down on `destroy`, when the setting is off (on project open or capture switch), and when the capture project is closed.
+
 ## [1.8.0]
 ### Fixed
 - Prevent startup Home layout loading from pulling users out of an already-open StageCraft workspace.

--- a/source/extensions/lightspeed.trex.control.stagecraft/lightspeed/trex/control/stagecraft/setup.py
+++ b/source/extensions/lightspeed.trex.control.stagecraft/lightspeed/trex/control/stagecraft/setup.py
@@ -58,8 +58,42 @@ from omni.flux.utils.common import reset_default_attrs as _reset_default_attrs
 from omni.flux.utils.common.symlink import should_confirm_link_path_replacement as _should_confirm_link_path_replacement
 from omni.flux.utils.widget.resources import get_quicklayout_config as _get_quicklayout_config
 
+try:
+    from lightspeed.hydra.remix.core import hdremix_set_configvar as _hdremix_set_configvar
+except ImportError:  # the bridge is an optional dependency, absent in headless/CLI apps
+    _hdremix_set_configvar = None
+
 _TREX_IGNORE_UNSAVED_STAGE_ON_EXIT = "/app/file/trexIgnoreUnsavedOnExit"
 _DEFAULT_LAYOUT = "/app/trex/default_layout"
+
+# Capture GPU device-loss / hang hardening. Building Opacity Micromaps (OMM) for a capture's
+# thousands of alpha-tested meshes during stage realization can overrun the GPU and fault the Vulkan
+# device (VK_ERROR_DEVICE_LOST) or hang the main thread; prim count does not predict which captures
+# do this, so OMM is disabled for any capture project. OMM is a render-time optimization only, so
+# visuals, editing, and asset replacement are unaffected. The override must be pushed before
+# ``open_stage`` and re-asserted afterwards: dxvk-remix re-applies the capture's own graphics preset
+# after realization (re-enabling OMM) without touching the carb ``/rtx/*`` nodes.
+_RTX_OPTION_GRAPHICS_PRESET = "rtx.graphicsPreset"
+_RTX_OPTION_INTEGRATE_INDIRECT_MODE = "rtx.integrateIndirectMode"
+_RTX_OPTION_OMM_ENABLE = "rtx.opacityMicromap.enable"
+# dxvk-remix RtxOptions enums: GraphicsPreset 4 == Custom (so the User-layer writes win over the
+# Quality preset), IntegrateIndirectMode 1 == ReSTIR GI (off the heavier Neural Radiance Cache).
+_RTX_GRAPHICS_PRESET_CUSTOM = "4"
+_RTX_INTEGRATE_INDIRECT_MODE_RESTIR = "1"
+_RTX_OMM_DISABLED = "0"
+_SETTING_AUTO_SAFE_MODE = "/exts/lightspeed.trex.control.stagecraft/autoDisableOpacityMicromaps"
+# Re-assert cadence (seconds; <= 0 disables). ``hdremix_set_configvar`` only writes the dxvk-remix
+# RtxOptions User layer (never carb ``/rtx/*`` or omni.usd), so re-pushing is deadlock-free and a
+# runtime no-op when the value is already current.
+_SETTING_REASSERT_INTERVAL = "/exts/lightspeed.trex.control.stagecraft/opacityMicromapReassertIntervalSeconds"
+_DEFAULT_REASSERT_INTERVAL_SECONDS = 5.0
+
+
+def _set_hdremix_configvar(key: str, value: str):
+    """Set an HdRemix (dxvk-remix RtxOptions User-layer) config variable through the runtime bridge."""
+    if _hdremix_set_configvar is None:
+        raise RuntimeError("lightspeed.hydra.remix.core is not loaded (optional dependency)")
+    _hdremix_set_configvar(key, value)
 
 
 class Setup:
@@ -68,6 +102,11 @@ class Setup:
     _SWITCH_CAPTURE_COMMAND_NAME = "SwitchCaptureCommand"
     _DISABLE_STAGE_OPEN_LIGHTING_UNDO = False
     _LIGHTING_STAGE_OPEN_ORIGINAL = None
+    # Capture safe-mode bookkeeping. Class-level defaults keep the hooks safe even when a
+    # unit test builds Setup via ``__new__`` (bypassing ``__init__``).
+    _safe_mode_capture_path = None
+    _reassert_watch_task = None
+    _context = None
 
     def __init__(self) -> None:
         """Create StageCraft setup services, subscriptions, and startup layout guards."""
@@ -94,6 +133,9 @@ class Setup:
             "_sub_stage_event": None,
             "_context": None,
             "_capture_swap_undo_dialog_open": False,
+            # Capture safe-mode bookkeeping
+            "_safe_mode_capture_path": None,
+            "_reassert_watch_task": None,
         }
         for attr, value in self._default_attr.items():
             setattr(self, attr, value)
@@ -284,6 +326,9 @@ class Setup:
 
     def _on_import_layer(self, layer_type: _LayerType, path: str, existing_file: bool = False):
         if layer_type == _LayerType.capture:
+            # Disable Opacity Micromaps before the switched-to capture is realized so it cannot
+            # fault the GPU, and re-assert the overrides if safe mode is already armed this session.
+            self._apply_capture_safe_mode_on_switch(path)
             capture_layer = self._capture_core_setup.get_layer()
             requested_capture_identifier = omni.client.normalize_url(path) if path else None
             current_capture_identifier = capture_layer.identifier if capture_layer else None
@@ -318,6 +363,9 @@ class Setup:
         if not _ProjectWizardSchema.are_project_symlinks_valid(project_path):
             self.__show_project_open_wizard(project_path)
             return
+        # Must run before ``open_stage``: the renderer realizes the capture during ``open_stage``,
+        # so a post-open (stage-opened) override would be too late to prevent a device loss.
+        self._apply_capture_safe_mode(project_path)
         self.__set_stage_open_lighting_undo_disabled(True)
         omni.kit.window.file.open_stage(path)
         load_layout(_get_quicklayout_config(_LayoutFiles.WORKSPACE_PAGE))
@@ -451,7 +499,120 @@ class Setup:
         has_project = root_layer and not bool(root_layer.anonymous)
         self.__sub_sidebar_items.set_enabled(bool(has_project))
 
+    # --- Capture GPU device-loss / hang safe mode ------------------------------------------------
+
+    def _reassert_interval_seconds(self) -> float:
+        """Resolve the periodic re-assert interval (seconds); falls back to the default."""
+        value = carb.settings.get_settings().get(_SETTING_REASSERT_INTERVAL)
+        try:
+            return float(value) if value is not None else _DEFAULT_REASSERT_INTERVAL_SECONDS
+        except (TypeError, ValueError):
+            return _DEFAULT_REASSERT_INTERVAL_SECONDS
+
+    def _push_stability_configvars(self):
+        """Push the renderer overrides that keep a capture from faulting/hanging the GPU."""
+        # graphicsPreset=Custom first so the Quality preset stops shadowing the User-layer writes,
+        # then force ReSTIR GI (off the Neural Radiance Cache) and disable Opacity Micromaps.
+        _set_hdremix_configvar(_RTX_OPTION_GRAPHICS_PRESET, _RTX_GRAPHICS_PRESET_CUSTOM)
+        _set_hdremix_configvar(_RTX_OPTION_INTEGRATE_INDIRECT_MODE, _RTX_INTEGRATE_INDIRECT_MODE_RESTIR)
+        _set_hdremix_configvar(_RTX_OPTION_OMM_ENABLE, _RTX_OMM_DISABLED)
+
+    def _arm_safe_mode(self, source_path: str):
+        """Disable Opacity Micromaps, remember the source, and start the periodic re-assert watchdog."""
+        try:
+            self._push_stability_configvars()
+        except Exception as error:  # noqa: BLE001 - never break project open on a runtime hiccup
+            carb.log_warn(f"Failed to disable Opacity Micromaps for '{source_path}': {error}")
+            return
+        self._safe_mode_capture_path = str(source_path)
+        carb.log_info(
+            f"Disabled Opacity Micromaps for capture project '{source_path}' before stage realization "
+            "(graphicsPreset=Custom, integrateIndirectMode=ReSTIR GI, opacityMicromap.enable=0)."
+        )
+        self._start_reassert_watchdog()
+
+    def _apply_capture_safe_mode(self, project_path: Path):
+        """On project open: disable Opacity Micromaps before the project's capture is realized."""
+        if not carb.settings.get_settings().get(_SETTING_AUTO_SAFE_MODE):
+            self._stop_reassert_watchdog()
+            self._safe_mode_capture_path = None
+            return
+        self._arm_safe_mode(str(project_path))
+
+    def _apply_capture_safe_mode_on_switch(self, capture_path: str | None):
+        """On capture switch: keep Opacity Micromaps disabled for the switched-to capture."""
+        if not carb.settings.get_settings().get(_SETTING_AUTO_SAFE_MODE):
+            # Mirror the project-open teardown so an armed watchdog cannot outlive the toggle.
+            self._stop_reassert_watchdog()
+            self._safe_mode_capture_path = None
+            return
+        if self._safe_mode_capture_path is not None:
+            # Safe mode already armed this session -- just re-assert the overrides.
+            self._reassert_overrides_if_active()
+            return
+        self._arm_safe_mode(str(capture_path) if capture_path else "capture switch")
+
+    def _reassert_overrides_if_active(self):
+        """Re-push the overrides if safe mode is currently armed."""
+        if self._safe_mode_capture_path is None:
+            return
+        try:
+            self._push_stability_configvars()
+        except Exception as error:  # noqa: BLE001 - never break on a runtime hiccup
+            carb.log_warn(f"Failed to re-assert Opacity Micromap override: {error}")
+
+    def _start_reassert_watchdog(self):
+        """Periodically re-push the overrides so the capture's own preset cannot re-enable OMM.
+
+        Once the capture realizes, dxvk-remix applies the capture's own graphics preset (re-enabling
+        OMM) without mirroring it into the carb ``/rtx/*`` nodes, so no settings callback fires; only
+        a periodic re-push corrects the drift before the OMM build can fault the GPU.
+        """
+        interval = self._reassert_interval_seconds()
+        if interval <= 0:
+            return
+        if self._reassert_watch_task is not None and not self._reassert_watch_task.done():
+            return
+        self._reassert_watch_task = ensure_future(self._reassert_watch_loop(interval))
+        carb.log_info(f"Started capture stability watchdog (re-asserting renderer overrides every {interval:g}s).")
+
+    def _stop_reassert_watchdog(self):
+        """Cancel the periodic re-assert loop (no-op if it was never started)."""
+        if self._reassert_watch_task is not None and not self._reassert_watch_task.done():
+            self._reassert_watch_task.cancel()
+        self._reassert_watch_task = None
+
+    async def _reassert_watch_loop(self, interval: float):
+        """Re-assert the overrides every ``interval`` seconds while a capture project stays loaded.
+
+        Stage CLOSING events cannot drive teardown: opening project B over project A fires A's
+        CLOSING after safe mode was armed for B, stripping protection while B realizes. Instead each
+        tick inspects the stage: no stage (transition in flight) skips the push; an anonymous root
+        layer (project closed) disarms and exits.
+        """
+        try:
+            while self._safe_mode_capture_path is not None:
+                await asyncio.sleep(interval)
+                # The project may have been closed/swapped out while we slept.
+                if self._safe_mode_capture_path is None:
+                    break
+                stage = self._context.get_stage() if self._context else None
+                if self._context and stage is None:
+                    continue
+                root_layer = stage.GetRootLayer() if stage else None
+                if root_layer is not None and root_layer.anonymous:
+                    self._safe_mode_capture_path = None
+                    carb.log_info("Capture project closed; stopped re-asserting the Opacity Micromap override.")
+                    break
+                try:
+                    self._push_stability_configvars()
+                except Exception as error:  # noqa: BLE001 - a transient hiccup must not kill the loop
+                    carb.log_warn(f"Periodic capture stability re-assert failed: {error}")
+        except asyncio.CancelledError:
+            pass
+
     def destroy(self):
+        self._stop_reassert_watchdog()
         self.__set_stage_open_lighting_undo_disabled(False)
         self.__uninstall_stage_open_lighting_undo_patch()
         _reset_default_attrs(self)

--- a/source/extensions/lightspeed.trex.control.stagecraft/lightspeed/trex/control/stagecraft/tests/unit/test_setup.py
+++ b/source/extensions/lightspeed.trex.control.stagecraft/lightspeed/trex/control/stagecraft/tests/unit/test_setup.py
@@ -343,3 +343,272 @@ class TestSetup(omni.kit.test.AsyncTestCase):
             mock_reset_default_attrs.assert_called_once_with(setup)
 
         Setup._DISABLE_STAGE_OPEN_LIGHTING_UNDO = original_disable_lighting_undo
+
+    # --- Capture GPU device-loss / hang safe mode ------------------------------------------------
+
+    async def test_open_stage_applies_capture_safe_mode_before_open_stage(self):
+        # Regression: the earlier gate disabled Opacity Micromaps on the stage-OPENED event, i.e.
+        # AFTER the capture was already realized and could fault/hang the GPU. The override MUST run
+        # before ``open_stage``. This pins that ordering.
+        setup = Setup.__new__(Setup)
+        calls = []
+        setup._apply_capture_safe_mode = MagicMock(side_effect=lambda project_path: calls.append("safe_mode"))
+
+        with (
+            patch("lightspeed.trex.control.stagecraft.setup._ProjectWizardSchema") as mock_schema,
+            patch("lightspeed.trex.control.stagecraft.setup._should_confirm_link_path_replacement", return_value=False),
+            patch(
+                "lightspeed.trex.control.stagecraft.setup.omni.kit.window.file.open_stage",
+                side_effect=lambda path: calls.append("open_stage"),
+            ),
+            patch("lightspeed.trex.control.stagecraft.setup.load_layout"),
+            patch("lightspeed.trex.control.stagecraft.setup._get_quicklayout_config"),
+            patch.object(Setup, "_Setup__set_stage_open_lighting_undo_disabled"),
+        ):
+            mock_schema.is_project_file_valid.return_value = True
+            mock_schema.is_deps_directory_valid.return_value = True
+            mock_schema.are_project_symlinks_valid.return_value = True
+            setup._Setup__open_stage_and_load_layout("C:/proj/TRLRTX.usda")
+
+        # Assert: safe mode applied first, then the stage is opened.
+        self.assertEqual(calls, ["safe_mode", "open_stage"])
+        setup._apply_capture_safe_mode.assert_called_once()
+
+    async def test_apply_capture_safe_mode_arms_when_enabled(self):
+        # With the toggle on, opening any capture project disables OMM (push), remembers the source,
+        # and starts the periodic re-assert watchdog.
+        setup = Setup.__new__(Setup)
+        setup._safe_mode_capture_path = None
+        setup._push_stability_configvars = MagicMock()
+        setup._start_reassert_watchdog = MagicMock()
+
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = True  # autoDisableOpacityMicromaps enabled
+
+        from pathlib import Path as _Path  # noqa: PLC0415
+
+        with patch("lightspeed.trex.control.stagecraft.setup.carb.settings.get_settings", return_value=mock_settings):
+            setup._apply_capture_safe_mode(_Path("C:/proj/TRLRTX.usda"))
+
+        setup._push_stability_configvars.assert_called_once_with()
+        setup._start_reassert_watchdog.assert_called_once_with()
+        self.assertEqual(setup._safe_mode_capture_path, str(_Path("C:/proj/TRLRTX.usda")))
+
+    async def test_apply_capture_safe_mode_disabled_when_toggle_off(self):
+        # With the toggle off, nothing is pushed and any prior watchdog is torn down.
+        setup = Setup.__new__(Setup)
+        setup._safe_mode_capture_path = "c:/old/trlrtx.usda"
+        setup._stop_reassert_watchdog = MagicMock()
+        setup._push_stability_configvars = MagicMock()
+
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = False
+
+        from pathlib import Path as _Path  # noqa: PLC0415
+
+        with patch("lightspeed.trex.control.stagecraft.setup.carb.settings.get_settings", return_value=mock_settings):
+            setup._apply_capture_safe_mode(_Path("C:/proj/TRLRTX.usda"))
+
+        setup._stop_reassert_watchdog.assert_called_once_with()
+        setup._push_stability_configvars.assert_not_called()
+        self.assertIsNone(setup._safe_mode_capture_path)
+
+    async def test_apply_capture_safe_mode_on_switch_reasserts_when_armed(self):
+        # Switching capture while safe mode is already armed just re-asserts the override.
+        setup = Setup.__new__(Setup)
+        setup._safe_mode_capture_path = "c:/proj/trlrtx.usda"
+        setup._reassert_overrides_if_active = MagicMock()
+        setup._arm_safe_mode = MagicMock()
+
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = True
+
+        with patch("lightspeed.trex.control.stagecraft.setup.carb.settings.get_settings", return_value=mock_settings):
+            setup._apply_capture_safe_mode_on_switch("c:/proj/deps/captures/england__5.usd")
+
+        setup._reassert_overrides_if_active.assert_called_once_with()
+        setup._arm_safe_mode.assert_not_called()
+
+    async def test_apply_capture_safe_mode_on_switch_arms_when_not_armed(self):
+        # Switching capture when safe mode is not yet armed arms it for the switched-to capture.
+        setup = Setup.__new__(Setup)
+        setup._safe_mode_capture_path = None
+        setup._arm_safe_mode = MagicMock()
+
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = True
+
+        with patch("lightspeed.trex.control.stagecraft.setup.carb.settings.get_settings", return_value=mock_settings):
+            setup._apply_capture_safe_mode_on_switch("c:/proj/deps/captures/england__5.usd")
+
+        setup._arm_safe_mode.assert_called_once_with("c:/proj/deps/captures/england__5.usd")
+
+    async def test_reassert_watch_loop_reasserts_configvars(self):
+        # The pre-open push only covers initial realization; dxvk-remix re-applies the capture's own
+        # preset a few seconds later (re-enabling OMM / NRC) WITHOUT touching the /rtx/* carb nodes,
+        # so the periodic watchdog is what corrects the drift -- it must re-push every tick while a
+        # capture stays loaded.
+        setup = Setup.__new__(Setup)
+        setup._safe_mode_capture_path = "c:/proj/deps/captures/bolivia__2.usd"
+
+        ticks = {"count": 0}
+
+        def _push_and_eventually_close():
+            ticks["count"] += 1
+            if ticks["count"] >= 2:
+                setup._safe_mode_capture_path = None  # simulate the project closing after two re-asserts
+
+        setup._push_stability_configvars = MagicMock(side_effect=_push_and_eventually_close)
+
+        with patch("lightspeed.trex.control.stagecraft.setup.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            await setup._reassert_watch_loop(5.0)
+
+        self.assertEqual(setup._push_stability_configvars.call_count, 2)
+        mock_sleep.assert_awaited_with(5.0)
+        self.assertIsNone(setup._safe_mode_capture_path)
+
+    async def test_reassert_watch_loop_noop_when_safe_mode_inactive(self):
+        # Safe mode not armed -> the loop exits immediately without sleeping or pushing.
+        setup = Setup.__new__(Setup)
+        setup._safe_mode_capture_path = None
+        setup._push_stability_configvars = MagicMock()
+
+        with patch("lightspeed.trex.control.stagecraft.setup.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            await setup._reassert_watch_loop(5.0)
+
+        mock_sleep.assert_not_awaited()
+        setup._push_stability_configvars.assert_not_called()
+
+    async def test_reassert_watch_loop_survives_push_failure(self):
+        # A transient runtime hiccup during a re-assert must not kill the loop; it should log and
+        # keep protecting the session until the project closes.
+        setup = Setup.__new__(Setup)
+        setup._safe_mode_capture_path = "c:/proj/deps/captures/bolivia__2.usd"
+
+        ticks = {"count": 0}
+
+        def _flaky_push():
+            ticks["count"] += 1
+            if ticks["count"] == 1:
+                raise RuntimeError("HdRemix not ready")
+            setup._safe_mode_capture_path = None
+
+        setup._push_stability_configvars = MagicMock(side_effect=_flaky_push)
+
+        with (
+            patch("lightspeed.trex.control.stagecraft.setup.asyncio.sleep", new=AsyncMock()),
+            patch("lightspeed.trex.control.stagecraft.setup.carb.log_warn") as mock_log_warn,
+        ):
+            await setup._reassert_watch_loop(5.0)
+
+        self.assertEqual(setup._push_stability_configvars.call_count, 2)
+        mock_log_warn.assert_called_once()
+
+    async def test_start_reassert_watchdog_disabled_when_interval_non_positive(self):
+        # Interval <= 0 disables the periodic re-assert entirely.
+        setup = Setup.__new__(Setup)
+        setup._reassert_watch_task = None
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = 0
+
+        with (
+            patch("lightspeed.trex.control.stagecraft.setup.carb.settings.get_settings", return_value=mock_settings),
+            patch("lightspeed.trex.control.stagecraft.setup.ensure_future") as mock_ensure_future,
+        ):
+            setup._start_reassert_watchdog()
+
+        mock_ensure_future.assert_not_called()
+        self.assertIsNone(setup._reassert_watch_task)
+
+    async def test_start_reassert_watchdog_creates_task(self):
+        # A positive interval schedules the watch loop exactly once.
+        setup = Setup.__new__(Setup)
+        setup._reassert_watch_task = None
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = 5.0
+        sentinel_task = MagicMock()
+        sentinel_task.done.return_value = False
+
+        with (
+            patch("lightspeed.trex.control.stagecraft.setup.carb.settings.get_settings", return_value=mock_settings),
+            patch("lightspeed.trex.control.stagecraft.setup.ensure_future", return_value=sentinel_task) as mock_ef,
+            # Avoid building a real coroutine (and its "never awaited" warning) since ensure_future is mocked.
+            patch.object(Setup, "_reassert_watch_loop", return_value=MagicMock()),
+        ):
+            setup._start_reassert_watchdog()
+
+        mock_ef.assert_called_once()
+        self.assertIs(setup._reassert_watch_task, sentinel_task)
+
+    async def test_stop_reassert_watchdog_cancels_task(self):
+        setup = Setup.__new__(Setup)
+        task = MagicMock()
+        task.done.return_value = False
+        setup._reassert_watch_task = task
+
+        setup._stop_reassert_watchdog()
+
+        task.cancel.assert_called_once_with()
+        self.assertIsNone(setup._reassert_watch_task)
+
+    async def test_apply_capture_safe_mode_on_switch_disarms_when_toggle_off(self):
+        # Turning the toggle off and then switching captures must tear down an already-armed
+        # watchdog (mirroring the project-open path) instead of leaving it re-asserting forever.
+        setup = Setup.__new__(Setup)
+        setup._safe_mode_capture_path = "c:/proj/trlrtx.usda"
+        setup._stop_reassert_watchdog = MagicMock()
+        setup._arm_safe_mode = MagicMock()
+        setup._reassert_overrides_if_active = MagicMock()
+
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = False
+
+        with patch("lightspeed.trex.control.stagecraft.setup.carb.settings.get_settings", return_value=mock_settings):
+            setup._apply_capture_safe_mode_on_switch("c:/proj/deps/captures/england__5.usd")
+
+        setup._stop_reassert_watchdog.assert_called_once_with()
+        self.assertIsNone(setup._safe_mode_capture_path)
+        setup._arm_safe_mode.assert_not_called()
+        setup._reassert_overrides_if_active.assert_not_called()
+
+    async def test_reassert_watch_loop_disarms_when_project_closed(self):
+        # An anonymous root layer means the capture project was closed (empty home stage):
+        # the loop must disarm and exit instead of pushing renderer overrides forever.
+        setup = Setup.__new__(Setup)
+        setup._safe_mode_capture_path = "c:/proj/deps/captures/bolivia__2.usd"
+        setup._push_stability_configvars = MagicMock()
+        anonymous_root = MagicMock()
+        anonymous_root.anonymous = True
+        stage = MagicMock()
+        stage.GetRootLayer.return_value = anonymous_root
+        setup._context = MagicMock()
+        setup._context.get_stage.return_value = stage
+
+        with patch("lightspeed.trex.control.stagecraft.setup.asyncio.sleep", new=AsyncMock()):
+            await setup._reassert_watch_loop(5.0)
+
+        setup._push_stability_configvars.assert_not_called()
+        self.assertIsNone(setup._safe_mode_capture_path)
+
+    async def test_reassert_watch_loop_skips_push_without_stage(self):
+        # No stage while a context exists means a stage transition is in flight (open_stage tears
+        # the old stage down before the new one attaches): stay armed but do not push that tick.
+        setup = Setup.__new__(Setup)
+        setup._safe_mode_capture_path = "c:/proj/deps/captures/bolivia__2.usd"
+        setup._push_stability_configvars = MagicMock()
+        setup._context = MagicMock()
+        setup._context.get_stage.return_value = None
+
+        ticks = {"count": 0}
+
+        async def _sleep_then_close(_interval):
+            ticks["count"] += 1
+            if ticks["count"] >= 2:
+                setup._safe_mode_capture_path = None  # simulate the session ending after two ticks
+
+        with patch("lightspeed.trex.control.stagecraft.setup.asyncio.sleep", new=_sleep_then_close):
+            await setup._reassert_watch_loop(5.0)
+
+        self.assertEqual(ticks["count"], 2)
+        setup._push_stability_configvars.assert_not_called()
+        self.assertIsNone(setup._safe_mode_capture_path)


### PR DESCRIPTION
## Problem

Opening a capture project (or switching captures) in StageCraft can fault the Vulkan device (`VK_ERROR_DEVICE_LOST`) or hang the main thread seconds after `open_stage`, dropping an Aftermath dump. A game capture is thousands of small alpha-tested meshes; building Opacity Micromaps (OMM) for all of them during stage realization can overrun the path tracer's GPU working set, and with no per-capture GPU budget ceiling to fall back on, the device faults instead of degrading.

Prim count does not reliably predict which captures do this — in testing, a 599 KB capture hung while much larger ones did not — so a "heavy capture" heuristic is not a safe gate.

## Fix

`lightspeed.trex.control.stagecraft` now disables OMM for any capture project **before** `open_stage` realizes the stage, by pushing `rtx.graphicsPreset=Custom`, `rtx.integrateIndirectMode=ReSTIR GI`, and `rtx.opacityMicromap.enable=0` through the HdRemix bridge (`lightspeed.hydra.remix.core`, added as an optional dependency). The same override is applied before a switched-to capture is realized.

A watchdog re-asserts the override every `opacityMicromapReassertIntervalSeconds` (default 5s): dxvk-remix re-applies the capture's own graphics preset a few seconds after realization — re-enabling OMM without touching the carb `/rtx/*` nodes, so no settings callback fires — which means a one-shot override silently loses and the GPU faults ~1 minute later anyway. `hdremix_set_configvar` writes only to the dxvk-remix RtxOptions User layer, so the periodic re-push cannot trigger a render-settings reload and is a runtime no-op when the value is already current. The watchdog is stage-aware: it skips pushes during stage transitions and disarms itself when the project is closed (stage-close events can't drive teardown — they fire mid-`open_stage` when loading one project over another, which would strip protection exactly while the new capture realizes).

OMM is a render-time optimization for alpha-tested geometry only, so disabling it never changes visuals and never affects editing or asset replacement — it trades a little alpha-tested ray-tracing performance for stability. The behavior is gated by a new `autoDisableOpacityMicromaps` setting (default on); the watchdog is torn down on `destroy` and whenever the setting is off. The extension is bumped to 1.8.1 with changelog entries.

## Verification

- Verified on an RTX 5090: a Tomb Raider: Legend capture project that previously device-lost the GPU on open now logs the pre-open override (`Disabled Opacity Micromaps for capture project ... before stage realization`) plus the watchdog start, dxvk-remix confirms `[RTX] Opacity Micromap: disabled` / `Integrate Indirect Mode: ReSTIR GI - activated`, and the project opens cleanly with no device loss and no Aftermath dump (including after sitting past the point where the capture's preset used to re-enable OMM).
- Unit tests added in `tests/unit/test_setup.py`, including a regression test pinning that the override runs before `open_stage` (an earlier attempt hooked the stage-OPENED event, which is after realization and too late), plus coverage for the toggle-off teardown paths and the stage-aware watchdog.
- `format_code.bat --verify`, `lint_code.bat all`, `check_forbidden_words`, `check_test_file_location`, and `check_changelog` all pass locally.

## Note for reviewers

This is deliberately a toolkit-side mitigation. The root-cause alternative would be a per-capture OMM-build VRAM budget/throttle in dxvk-remix so OMM could stay enabled — happy to rework in that direction if you'd prefer the fix live at the renderer level.
